### PR TITLE
[CLEO-5652] Front Messages with URLs are stripped way

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,7 +63,7 @@ export const getPreviewData = async (text: string) => {
   }
 
   try {
-    const link = text.toLowerCase().match(REGEX_LINK)?.[0]
+    const link = text.match(REGEX_LINK)?.[0]
 
     if (!link) return previewData
 


### PR DESCRIPTION
## Description
- Remove `toLowerCase`. It makes the original url to be immutable, which is important for case sensitive urls.